### PR TITLE
🐢 Reduce CPU usage of window UI thread

### DIFF
--- a/Bearded.Graphics/Windowing/Window.cs
+++ b/Bearded.Graphics/Windowing/Window.cs
@@ -88,6 +88,7 @@ namespace Bearded.Graphics.Windowing
             {
                 window.ProcessEvents();
                 OnUpdateUIThread();
+                Thread.Sleep(1);
             }
         }
 


### PR DESCRIPTION

## ✨ What's this?
Right now, the window class draws 100% CPU by fetching UI events as fast as possible.

Instead, ~1000 times a second is plenty and reduces CPU time to almost nothing.

Down the line, we should refactor this to wait until there are new events to handle.

## 🏗 How is it done?
🧵.💤


### 🔬 Why not another way?
It's simple and the class isn't great anyway. It'll do for now.
