### PR TITLE
👷‍♂️ Explicitly specify the csproj to pack for NuGet publish

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -35,7 +35,7 @@ jobs:
       # Note that we substr the release version to get the numbers only, without
       # the 'v' prefix.
       - name: Pack binary
-        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1}
+        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Graphics/Bearded.Graphics.csproj
 
       # Create a GitHub release
       - name: Create a Release


### PR DESCRIPTION
## ✨ What's this?
Fixes the GitHub workflow to only publish the main library project.

## 🔍 Why do we want this?
We don't want to publish the example projects to GitHub.

## 🏗 How is it done?
Pass in the path to the project ([documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack#arguments))

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
Seems like explicitly controlling the packages we push isn't so bad.

### 🦋 Side effects
N/A

## 💡 Review hints
N/A
