### PR TITLE
🐛 Make lines draw at their actual line width

### DIFF
--- a/Bearded.Graphics/Shapes/ShapeDrawer2.cs
+++ b/Bearded.Graphics/Shapes/ShapeDrawer2.cs
@@ -160,7 +160,7 @@ namespace Bearded.Graphics.Shapes
         {
             var vx = x2 - x1;
             var vy = y1 - y2; // switch order for correct normal direction
-            var ilxy = lineWidth / (float)Math.Sqrt(vx * vx + vy * vy);
+            var ilxy = 0.5f * lineWidth / (float)Math.Sqrt(vx * vx + vy * vy);
             var nx = vy * ilxy;
             var ny = vx * ilxy;
             meshBuilder.AddQuad(


### PR DESCRIPTION
## ✨ What's this?
This PR fixes a bug that causes lines to be drawn at twice the width that is specified in `lineWidth`

## 🔍 Why do we want this?
It's a bug. Specifically, this creates an inconsistent API with the other draw methods, that do consider `lineWidth` as their actual line width:

![image](https://user-images.githubusercontent.com/828553/126818566-a22cb9a8-44cf-4b28-b4d4-d04ccfb44c20.png)

(Note: this image uses a new arc drawing function, but this is directly copied from the circle drawing function in this library).

## 🏗 How is it done?
The line drawing function works by calculating the normal to the line, and adding that to the starting and ending point. The length of this normal is the entire `lineWidth`, meaning we are adding the `lineWidth` on both sides of the line to draw. In the image below, `n` is the normal, and since n is built such that `||n|| = lineWidth`, the total width of the line becomes double that.

![image](https://user-images.githubusercontent.com/828553/126819216-b527a10e-f6e3-4e0b-883d-ad2e0cc0460b.png)

This PR changes `ilxy`, which is the ratio of the line to the line width, to be the ratio of the line to the desire normal length by multiplying by 0.5, creating the desired line.

### 💥 Breaking changes
This PR may have significant impact on the rendering of lines, potentially causing large changes. However, I believe this is acceptable in the larger goal of creating a consistent interface and functionality.

### 🔬 Why not another way?
#### Alternative: create a new interface
It would be hard to create a whole new method with a new name that is still consistent with the existing naming convention. We could consider using this as an opportunity to rename the method to `DrawLineSegment`, but now we have two very similar methods working very differently, only creating more confusion. Better to bite the bullet.

### 🦋 Side effects
See breaking changes.

## 💡 Review hints
It took me a bit to figure out the logic of this method, so I recommend referring to the explanations above to help with the review.
