### PR TITLE
🐛 Add GameWindow.Initialize call in sample projects

### DIFF
--- a/Bearded.Graphics.Examples/01.Basics/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/01.Basics/EntryPoint.cs
@@ -8,6 +8,7 @@ namespace Bearded.Graphics.Examples.Basics
             // Initialize an instance of the game window. This represents the game or application at the highest
             // level, and will be the entry point for your game loop.
             var gameWindow = new GameWindow();
+            gameWindow.Initialize();
             // Run the game window.
             gameWindow.Run();
         }

--- a/Bearded.Graphics.Examples/02.IndexBuffer/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/02.IndexBuffer/EntryPoint.cs
@@ -6,7 +6,7 @@ namespace Bearded.Graphics.Examples.IndexBuffer
         public static void Main()
         {
             var gameWindow = new GameWindow();
-
+            gameWindow.Initialize();
             gameWindow.Run();
         }
     }

--- a/Bearded.Graphics.Examples/08.PostProcessing/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/08.PostProcessing/EntryPoint.cs
@@ -5,7 +5,7 @@ namespace Bearded.Graphics.Examples.PostProcessing
         public static void Main()
         {
             var gameWindow = new GameWindow();
-
+            gameWindow.Initialize();
             gameWindow.Run();
         }
     }

--- a/Bearded.Graphics.Examples/12.Text/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/12.Text/EntryPoint.cs
@@ -8,6 +8,7 @@ namespace Bearded.Graphics.Examples.Text
             // Initialize an instance of the game window. This represents the game or application at the highest
             // level, and will be the entry point for your game loop.
             var gameWindow = new GameWindow();
+            gameWindow.Initialize();
             // Run the game window.
             gameWindow.Run();
         }

--- a/Bearded.Graphics.Examples/20.Mandelbrot/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/20.Mandelbrot/EntryPoint.cs
@@ -6,6 +6,7 @@ namespace Bearded.Graphics.Examples.Mandelbrot
         public static void Main()
         {
             var gameWindow = new GameWindow();
+            gameWindow.Initialize();
             gameWindow.Run();
         }
     }


### PR DESCRIPTION
## ✨ What's this?
Hey, I noticed your samples didn't work. Got this error when I tried running them:

```bat
Unhandled exception. System.InvalidOperationException: Window must be initialised before running.
   at Bearded.Graphics.Windowing.Window.Run() in B:\src\graphics\Bearded.Graphics\Windowing\Window.cs:line 98
   at Bearded.Graphics.Examples.PostProcessing.EntryPoint.Main() in B:\src\graphics\Bearded.Graphics.Examples\08.PostProcessing\EntryPoint.cs:line 9
```

I figured out that adding a call to `GameWindow.Initialize` solves the problem.

### 🔬 Why not another way?

I noticed that `GameWindow.Initialize` confusingly returns a Task, but making Main async and awaiting the task seems to freeze the window. Hence the synchronous call. I noticed you too [do this synchronously in td](https://github.com/beardgame/td/blob/722fdf5a2dea665409e8b79ed1ed68f46618fd22/src/Bearded.TD/EntryPoint.cs#L52) so I guess it's fine.