### PR TITLE
🔀 Switch windowing to main thread and GL to separate one

### DIFF
--- a/Bearded.Graphics.Examples/01.Basics/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/01.Basics/EntryPoint.cs
@@ -8,7 +8,6 @@ namespace Bearded.Graphics.Examples.Basics
             // Initialize an instance of the game window. This represents the game or application at the highest
             // level, and will be the entry point for your game loop.
             var gameWindow = new GameWindow();
-            gameWindow.Initialize();
             // Run the game window.
             gameWindow.Run();
         }

--- a/Bearded.Graphics.Examples/02.IndexBuffer/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/02.IndexBuffer/EntryPoint.cs
@@ -6,7 +6,6 @@ namespace Bearded.Graphics.Examples.IndexBuffer
         public static void Main()
         {
             var gameWindow = new GameWindow();
-            gameWindow.Initialize();
             gameWindow.Run();
         }
     }

--- a/Bearded.Graphics.Examples/03.RenderSettings/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/03.RenderSettings/EntryPoint.cs
@@ -6,7 +6,6 @@ namespace Bearded.Graphics.Examples.RenderSettings
         public static void Main()
         {
             var gameWindow = new GameWindow();
-            gameWindow.Initialize();
             gameWindow.Run();
         }
     }

--- a/Bearded.Graphics.Examples/08.PostProcessing/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/08.PostProcessing/EntryPoint.cs
@@ -5,7 +5,6 @@ namespace Bearded.Graphics.Examples.PostProcessing
         public static void Main()
         {
             var gameWindow = new GameWindow();
-            gameWindow.Initialize();
             gameWindow.Run();
         }
     }

--- a/Bearded.Graphics.Examples/12.Text/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/12.Text/EntryPoint.cs
@@ -8,7 +8,6 @@ namespace Bearded.Graphics.Examples.Text
             // Initialize an instance of the game window. This represents the game or application at the highest
             // level, and will be the entry point for your game loop.
             var gameWindow = new GameWindow();
-            gameWindow.Initialize();
             // Run the game window.
             gameWindow.Run();
         }

--- a/Bearded.Graphics.Examples/20.Mandelbrot/EntryPoint.cs
+++ b/Bearded.Graphics.Examples/20.Mandelbrot/EntryPoint.cs
@@ -6,7 +6,6 @@ namespace Bearded.Graphics.Examples.Mandelbrot
         public static void Main()
         {
             var gameWindow = new GameWindow();
-            gameWindow.Initialize();
             gameWindow.Run();
         }
     }


### PR DESCRIPTION
## ✨ What's this?
This switches windowing to run on the main thread again, and GL/the actual game update loop to run on a separate thread instead.

## 🔍 Why do we want this?

Next to cleaning up the code a little bit more (and now no longer requiring a synchronization event or the previously added Initialize method), this is essential to make apps run on MacOS, where windowing MUST happen on the main thread.

### 💥 Breaking changes
- Removed Initialize()
- Could break some weird thread shenanigans

### 🦋 Side effects
While I was there, I tried making the event loop more efficient by waiting for events with a timeout. empirically I don't see a difference, so I figure it's fine.

## 💡 Review hints
I [committed this to TD](https://github.com/beardgame/td/commit/f67c854805d22c68bc59fdde8ec49d2027ea78fa), if you'd like to test it there, but you can also check the examples (the Mandelbrot one shows that input still works too).