### PR TITLE
🏷 Add pipeline debugging

### DIFF
--- a/Bearded.Graphics/Debugging/KHRDebugExtension.cs
+++ b/Bearded.Graphics/Debugging/KHRDebugExtension.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using OpenTK.Graphics.OpenGL;
+
+namespace Bearded.Graphics.Debugging
+{
+    public abstract class KHRDebugExtension
+    {
+        private static KHRDebugExtension? instance;
+        public static KHRDebugExtension Instance => instance ??= createInstanceWithAvailableFunctionality();
+
+        private KHRDebugExtension()
+        {
+        }
+
+        private static KHRDebugExtension createInstanceWithAvailableFunctionality()
+        {
+            if (khrDebugExtensionIsAvailable())
+                return new ActualImplementation();
+            return new DummyImplementation();
+        }
+
+        private static bool khrDebugExtensionIsAvailable()
+        {
+            var count = GL.GetInteger(GetPName.NumExtensions);
+
+            return Enumerable.Range(0, count)
+                .Select(i => GL.GetString(StringNameIndexed.Extensions, i))
+                .Contains("GL_KHR_debug");
+        }
+
+        public virtual void SetObjectLabel(ObjectLabelIdentifier identifier, int name, string label) { }
+        public virtual void PushDebugGroup(DebugSourceExternal source, int id, string name) { }
+        public virtual void PopDebugGroup() { }
+
+        private sealed class ActualImplementation : KHRDebugExtension
+        {
+            public override void SetObjectLabel(ObjectLabelIdentifier identifier, int name, string label)
+            {
+                GL.ObjectLabel(identifier, name, label.Length, label);
+            }
+
+            public override void PushDebugGroup(DebugSourceExternal source, int id, string name)
+            {
+                GL.PushDebugGroup(source, id, name.Length, name);
+            }
+
+            public override void PopDebugGroup()
+            {
+                GL.PopDebugGroup();
+            }
+        }
+
+        private sealed class DummyImplementation : KHRDebugExtension
+        {
+        }
+    }
+}

--- a/Bearded.Graphics/Pipelines/Context/DebugGroup.cs
+++ b/Bearded.Graphics/Pipelines/Context/DebugGroup.cs
@@ -1,4 +1,5 @@
 using System;
+using Bearded.Graphics.Debugging;
 using OpenTK.Graphics.OpenGL;
 
 namespace Bearded.Graphics.Pipelines.Context
@@ -20,12 +21,12 @@ namespace Bearded.Graphics.Pipelines.Context
         public void StoreCurrentValueAndApplyChange(TState state)
         {
             var name = getName(state);
-            GL.PushDebugGroup(DebugSourceExternal.DebugSourceThirdParty, 0, name.Length, name);
+            KHRDebugExtension.Instance.PushDebugGroup(DebugSourceExternal.DebugSourceThirdParty, 0, name);
         }
 
         public void RestoreToStoredValue()
         {
-            GL.PopDebugGroup();
+            KHRDebugExtension.Instance.PopDebugGroup();
         }
     }
 }

--- a/Bearded.Graphics/Pipelines/Context/DebugGroup.cs
+++ b/Bearded.Graphics/Pipelines/Context/DebugGroup.cs
@@ -1,0 +1,31 @@
+using System;
+using OpenTK.Graphics.OpenGL;
+
+namespace Bearded.Graphics.Pipelines.Context
+{
+    sealed class DebugGroup<TState> : IContextChange<TState>
+    {
+        private readonly Func<TState, string> getName;
+
+        public DebugGroup(string name)
+            : this(_ => name)
+        {
+        }
+
+        public DebugGroup(Func<TState,string> getName)
+        {
+            this.getName = getName;
+        }
+
+        public void StoreCurrentValueAndApplyChange(TState state)
+        {
+            var name = getName(state);
+            GL.PushDebugGroup(DebugSourceExternal.DebugSourceThirdParty, 0, name.Length, name);
+        }
+
+        public void RestoreToStoredValue()
+        {
+            GL.PopDebugGroup();
+        }
+    }
+}

--- a/Bearded.Graphics/Pipelines/Context/PipelineContextBuilder.cs
+++ b/Bearded.Graphics/Pipelines/Context/PipelineContextBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Drawing;
+using Bearded.Graphics.Debugging;
 using Bearded.Graphics.Textures;
 
 namespace Bearded.Graphics.Pipelines.Context

--- a/Bearded.Graphics/Pipelines/Context/PipelineContextBuilder.cs
+++ b/Bearded.Graphics/Pipelines/Context/PipelineContextBuilder.cs
@@ -31,6 +31,12 @@ namespace Bearded.Graphics.Pipelines.Context
         public PipelineContextBuilder<TState> SetViewport(Func<TState, Rectangle> getViewport)
             => with(new Viewport<TState>(getViewport));
 
+        public PipelineContextBuilder<TState> SetDebugName(string name)
+            => with(new DebugGroup<TState>(name));
+
+        public PipelineContextBuilder<TState> SetDebugName(Func<TState, string> getName)
+            => with(new DebugGroup<TState>(getName));
+
         private PipelineContextBuilder<TState> with(IContextChange<TState> change)
         {
             contextChanges.Add(change);

--- a/Bearded.Graphics/Pipelines/Pipeline.Textures.cs
+++ b/Bearded.Graphics/Pipelines/Pipeline.Textures.cs
@@ -7,6 +7,24 @@ namespace Bearded.Graphics.Pipelines
 {
     public static partial class Pipeline
     {
+
+        public static PipelineRenderTarget RenderTargetWithColors(string label, params PipelineTexture[] textures)
+        {
+            return withLabel(label, RenderTargetWithColors(textures));
+        }
+
+        public static PipelineRenderTarget RenderTargetWithDepthAndColors(
+            string label, PipelineDepthTexture depth, params PipelineTexture[] textures)
+        {
+            return withLabel(label, RenderTargetWithDepthAndColors(depth, textures));
+        }
+
+        private static PipelineRenderTarget withLabel(string label, PipelineRenderTarget target)
+        {
+            GL.ObjectLabel(ObjectLabelIdentifier.Framebuffer, target.Handle, label.Length, label);
+            return target;
+        }
+
         public static PipelineRenderTarget RenderTargetWithColors(params PipelineTexture[] textures)
         {
             return renderTarget(null, textures);
@@ -42,33 +60,45 @@ namespace Bearded.Graphics.Pipelines
         public static PipelineTexture Texture(
             PixelInternalFormat pixelFormat,
             int width = 1, int height = 1,
-            Action<Texture.Target>? setup = null)
+            Action<Texture.Target>? setup = null,
+            string? label = null)
         {
             var texture = Textures.Texture.Empty(width, height, pixelFormat);
 
+            optionalTextureSetup(texture, setup, label);
+
+            return new PipelineTexture(texture);
+        }
+        public static PipelineDepthTexture DepthTexture(
+            PixelInternalFormat pixelFormat,
+            int width = 1, int height = 1,
+            Action<Texture.Target>? setup = null,
+            string? label = null)
+        {
+            var texture = Textures.Texture.Empty(width, height, pixelFormat, PixelFormat.DepthComponent, PixelType.Float);
+
+            optionalTextureSetup(texture, target =>
+            {
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.DepthTextureMode, (int) All.Intensity);
+                setup?.Invoke(target);
+            }, label);
+
+            return new PipelineDepthTexture(texture);
+        }
+
+        private static void optionalTextureSetup(
+            Texture texture, Action<Texture.Target>? setup, string? label)
+        {
             if (setup != null)
             {
                 using var target = texture.Bind();
                 setup(target);
             }
 
-            return new PipelineTexture(texture);
-        }
-
-        public static PipelineDepthTexture DepthTexture(
-            PixelInternalFormat pixelFormat,
-            int width = 1, int height = 1,
-            Action<Texture.Target>? setup = null)
-        {
-            var texture = Textures.Texture.Empty(width, height, pixelFormat, PixelFormat.DepthComponent, PixelType.Float);
-
-            using (var target = texture.Bind())
+            if (label != null)
             {
-                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.DepthTextureMode, (int) All.Intensity);
-                setup?.Invoke(target);
+                GL.ObjectLabel(ObjectLabelIdentifier.Texture, texture.Handle, label.Length, label);
             }
-
-            return new PipelineDepthTexture(texture);
         }
     }
 }

--- a/Bearded.Graphics/Pipelines/Pipeline.Textures.cs
+++ b/Bearded.Graphics/Pipelines/Pipeline.Textures.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Bearded.Graphics.Debugging;
 using Bearded.Graphics.Textures;
 using OpenTK.Graphics.OpenGL;
 
@@ -21,7 +22,7 @@ namespace Bearded.Graphics.Pipelines
 
         private static PipelineRenderTarget withLabel(string label, PipelineRenderTarget target)
         {
-            GL.ObjectLabel(ObjectLabelIdentifier.Framebuffer, target.Handle, label.Length, label);
+            KHRDebugExtension.Instance.SetObjectLabel(ObjectLabelIdentifier.Framebuffer, target.Handle, label);
             return target;
         }
 
@@ -97,7 +98,7 @@ namespace Bearded.Graphics.Pipelines
 
             if (label != null)
             {
-                GL.ObjectLabel(ObjectLabelIdentifier.Texture, texture.Handle, label.Length, label);
+                KHRDebugExtension.Instance.SetObjectLabel(ObjectLabelIdentifier.Texture, texture.Handle, label);
             }
         }
     }


### PR DESCRIPTION

## ✨ What's this?
This adds (optional) [debug groups](https://www.khronos.org/opengl/wiki/Debug_Output#Scoping_messages) to our pipeline and [object labels](https://www.khronos.org/opengl/wiki/Debug_Output#Object_names) to pipeline textures and render targets.

## 🔍 Why do we want this?
This makes debugging in tools like RenderDoc significantly easier since it is much easier to find specific draw calls and to generally verify that intended rendering steps are happening, and in what order.

## 🏗 How is it done?
Using:
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPushDebugGroup.xhtml
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPopDebugGroup.xhtml
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glObjectLabel.xhtml

See also:
https://www.khronos.org/opengl/wiki/Debug_Output

### 💥 Breaking changes
New optional parameters are binary breaking, but the changes are code compatible.

### 🔬 Why not another way?
The used GL API is _the_ way to do this, and using the existing pipeline functionality felt natural.
Perhaps having two different patterns to give labels for textures and rendertargets (first vs last/optional parameter) isn't perfect, but I'm happy to change that signature down the line. I think it's ok for now. 

### 🦋 Side effects
I was able to find a rendering bug much faster and easier.

## 💡 Review hints
I tested this with RenderDoc and TD, where you can also see how these new APIs are used: https://github.com/beardgame/td/commit/c80add24a8d42ba8e1495803aaa1c49d2269465e
