### PR TITLE
🚰 Improve Pipeline

### DIFF
--- a/Bearded.Graphics/Pipelines/Context/BlendMode.cs
+++ b/Bearded.Graphics/Pipelines/Context/BlendMode.cs
@@ -1,0 +1,14 @@
+namespace Bearded.Graphics.Pipelines.Context
+{
+    public enum BlendMode
+    {
+        None = 0,
+        Alpha,
+        Add,
+        Subtract,
+        Multiply,
+        Premultiplied,
+        Min,
+        Max,
+    }
+}

--- a/Bearded.Graphics/Pipelines/Context/ColorMask.cs
+++ b/Bearded.Graphics/Pipelines/Context/ColorMask.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Bearded.Graphics.Pipelines.Context
+{
+    [Flags]
+    public enum ColorMask
+    {
+        DrawRed = 1,
+        DrawGreen = 2,
+        DrawBlue = 4,
+        DrawAlpha = 8,
+
+        DrawAll = DrawRed | DrawGreen | DrawBlue | DrawAlpha,
+    }
+
+    sealed class ColorMask<TState> : ContextChange<TState, ColorMask>
+    {
+        public ColorMask(ColorMask newValue) : base(newValue)
+        {
+        }
+
+        protected override ColorMask GetCurrent() => GLState.ColorMask;
+
+        protected override void Set(ColorMask value) => GLState.SetColorMask(value);
+    }
+}

--- a/Bearded.Graphics/Pipelines/Context/GLState.cs
+++ b/Bearded.Graphics/Pipelines/Context/GLState.cs
@@ -7,20 +7,21 @@ using static OpenTK.Graphics.OpenGL.BlendingFactor;
 
 namespace Bearded.Graphics.Pipelines.Context
 {
-    public enum BlendMode
-    {
-        None = 0,
-        Alpha,
-        Add,
-        Subtract,
-        Multiply,
-        Premultiplied,
-        Min,
-        Max,
-    }
-
     public static class GLState
     {
+        public static ColorMask ColorMask { get; private set; } = ColorMask.DrawAll;
+
+        public static void SetColorMask(ColorMask mask)
+        {
+            ColorMask = mask;
+            GL.ColorMask(
+                mask.HasFlag(ColorMask.DrawRed),
+                mask.HasFlag(ColorMask.DrawGreen),
+                mask.HasFlag(ColorMask.DrawBlue),
+                mask.HasFlag(ColorMask.DrawAll)
+                );
+        }
+
         public static int Framebuffer { get; private set; }
 
         public static void BindFramebuffer(int framebuffer)

--- a/Bearded.Graphics/Pipelines/Context/PipelineContextBuilder.cs
+++ b/Bearded.Graphics/Pipelines/Context/PipelineContextBuilder.cs
@@ -20,6 +20,9 @@ namespace Bearded.Graphics.Pipelines.Context
         public PipelineContextBuilder<TState> SetCullMode(CullMode cullMode)
             => with(new Culling<TState>(cullMode));
 
+        public PipelineContextBuilder<TState> SetColorMask(ColorMask mask)
+            => with(new ColorMask<TState>(mask));
+
         public PipelineContextBuilder<TState> SetDepthMode(DepthMode depthMode)
             => with(new DepthModeChange<TState>(depthMode));
 

--- a/Bearded.Graphics/Pipelines/Pipeline.Extensions.cs
+++ b/Bearded.Graphics/Pipelines/Pipeline.Extensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Bearded.Graphics.Pipelines.Steps;
+using Void = Bearded.Utilities.Void;
 
 namespace Bearded.Graphics.Pipelines
 {
@@ -14,6 +15,11 @@ namespace Bearded.Graphics.Pipelines
             this IPipeline<TStateInner> innerPipeline, Func<TStateOuter, TStateInner> selector)
         {
             return new Elevator<TStateInner,TStateOuter>(innerPipeline, selector);
+        }
+
+        public static void Execute(this IPipeline<Void> pipeline)
+        {
+            pipeline.Execute(default);
         }
     }
 }

--- a/Bearded.Graphics/Pipelines/Steps/WithContext.cs
+++ b/Bearded.Graphics/Pipelines/Steps/WithContext.cs
@@ -23,8 +23,9 @@ namespace Bearded.Graphics.Pipelines.Steps
 
             inner.Execute(state);
 
-            foreach (var change in changes)
+            for (var i = changes.Length - 1; i >= 0; i--)
             {
+                var change = changes[i];
                 change.RestoreToStoredValue();
             }
         }


### PR DESCRIPTION

## ✨ What's this?
This adds several small improvements to the pipeline (one commit each for easy review).

1. We now undo context changes in the opposite order in which they are applied, which means that things will work exactly as if each change was a nested WithContext call. This will also mean that we will now reset changes properly in case we make the same change twice in the same step (though I'm not sure why anyone would), instead of retaining the second to last set value. Another side effect is that the 'undo's will now be grouped in the same debug group in RenderDoc instead of in the following one, if the group debug name is set first (and hence popped last!).
2. Added color masking to pipeline context. It lets you select which of the RGBA channels you want to draw to and which not. There's another overload of glColorMask that takes the index of a specific framebuffer attachement, but I didn't bother going that far. The general case is what I need, so that's what I added.
3. I added an extension for void pipelines so that the user can cleanly call .Execute() instead of .Execute(default(Void)) or similar. This only specifically works with the Bearded.Utilities.Void type of course.

## 🔍 Why do we want this?
1. Arguably fixes a bug, makes debugging a little nicer and works more like I'd expect generally.
2. More feature. I needs it.
3. Sugar.

### 💥 Breaking changes
The first change is strictly speaking changing behaviour, but also, it's a bug.

### 🔬 Why not another way?
Could have done three different PRs, but will not do so unless you make me.

## 💡 Review hints
Check by commit.
