### PR TITLE
🚰 Add Pipeline.TextureUniforms

### DIFF
--- a/Bearded.Graphics/Core/RenderSettings/CompositeRenderSetting.cs
+++ b/Bearded.Graphics/Core/RenderSettings/CompositeRenderSetting.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bearded.Graphics.Shading;
+
+namespace Bearded.Graphics.RenderSettings
+{
+    public sealed class CompositeRenderSetting : IRenderSetting
+    {
+        private readonly ImmutableArray<IRenderSetting> settings;
+
+        public CompositeRenderSetting(IEnumerable<IRenderSetting> settings)
+        {
+            this.settings = settings.ToImmutableArray();
+        }
+
+        public void SetForProgram(ShaderProgram program)
+        {
+            foreach (var setting in settings)
+            {
+                setting.SetForProgram(program);
+            }
+        }
+
+        public IProgramRenderSetting ForProgram(ShaderProgram program)
+        {
+            return new ProgramSetting(settings.Select(s => s.ForProgram(program)));
+        }
+
+        private sealed class ProgramSetting : IProgramRenderSetting
+        {
+            private readonly ImmutableArray<IProgramRenderSetting> settings;
+
+            public ProgramSetting(IEnumerable<IProgramRenderSetting> settings)
+            {
+                this.settings = settings.ToImmutableArray();
+            }
+
+            public void Set()
+            {
+                foreach (var setting in settings)
+                {
+                    setting.Set();
+                }
+            }
+        }
+    }
+}

--- a/Bearded.Graphics/Pipelines/Pipeline.Textures.cs
+++ b/Bearded.Graphics/Pipelines/Pipeline.Textures.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Bearded.Graphics.Debugging;
+using Bearded.Graphics.RenderSettings;
 using Bearded.Graphics.Textures;
 using OpenTK.Graphics.OpenGL;
 
@@ -8,7 +9,6 @@ namespace Bearded.Graphics.Pipelines
 {
     public static partial class Pipeline
     {
-
         public static PipelineRenderTarget RenderTargetWithColors(string label, params PipelineTexture[] textures)
         {
             return withLabel(label, RenderTargetWithColors(textures));
@@ -100,6 +100,15 @@ namespace Bearded.Graphics.Pipelines
             {
                 KHRDebugExtension.Instance.SetObjectLabel(ObjectLabelIdentifier.Texture, texture.Handle, label);
             }
+        }
+
+        public static IRenderSetting TextureUniforms(
+            params (PipelineTextureBase Texture, string UniformName)[] textures)
+        {
+            return new CompositeRenderSetting(
+                textures.Select(
+                    (t, i) => new TextureUniform(t.UniformName, TextureUnit.Texture0 + i, t.Texture.Texture))
+            );
         }
     }
 }


### PR DESCRIPTION

## ✨ What's this?
Passing several textures as uniforms into a render step in the pipeline is verbose. This makes that much better. It also abstracts away texture units which in most cases we don't care about having control over.

## 🔍 Why do we want this?
Cleaner code is nice.

## 🏗 How is it done?
Using a new CompositeRenderSetting. Pretty straight forward.

## 💡 Review hints
See a usage example here: https://github.com/beardgame/td/commit/c1deb05454c7bcec5aa0623a04ccc64e9fbae96b#diff-0d39857e427038652fb7d5d8f6d3da8358bc82dcc4c414e900149228ec7e6552
