### PR TITLE
🔧 Increase .NET version to .NET 6 and clean up project files

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - ignore-for-release
+    authors:
+      - dependabot
+      - octocat
+  categories:
+    - title: 💥 Breaking changes
+      labels:
+        - breaking-change
+    - title: ✨ New features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bugfixes
+      labels:
+        - bug
+        - fix
+    - title: 📝 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -13,14 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.0
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            3.1.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build -c Release --no-restore
       - name: Test
         run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -13,11 +13,13 @@ jobs:
 
     steps:
       # Build library and run tests
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.0
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            3.1.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -39,15 +41,15 @@ jobs:
 
       # Create a GitHub release
       - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: Release ${{ env.RELEASE_VERSION }}
+          name: Release ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/*.nupkg"
 
       # Push the NuGet package to the package providers
       - name: Push release to NuGet

--- a/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
+++ b/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.Basics</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Basics</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
+++ b/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
@@ -8,6 +8,7 @@
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
+++ b/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.IndexBuffer</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.IndexBuffer</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
+++ b/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
@@ -8,6 +8,7 @@
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
+++ b/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
@@ -1,24 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
-        <RootNamespace>Bearded.Graphics.Examples.RenderSettings</RootNamespace>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Bearded.Graphics.Examples.RenderSettings</RootNamespace>
+    <AssemblyName>Bearded.Graphics.Examples.RenderSettings</AssemblyName>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\Bearded.Graphics\Bearded.Graphics.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Update="geometry.fs">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="geometry.vs">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>bin/Debug/</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>bin/Release/</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bearded.Graphics\Bearded.Graphics.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="geometry.fs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="geometry.vs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
+++ b/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <RootNamespace>Bearded.Graphics.Examples.RenderSettings</RootNamespace>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
+++ b/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.PostProcessing</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.PostProcessing</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
+++ b/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
@@ -8,6 +8,7 @@
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
+++ b/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.Text</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Text</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
+++ b/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
@@ -8,6 +8,7 @@
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
+++ b/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.Mandelbrot</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Mandelbrot</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
+++ b/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
@@ -8,6 +8,7 @@
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Bearded.Graphics/Bearded.Graphics.csproj
+++ b/Bearded.Graphics/Bearded.Graphics.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>annotations</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## ✨ What's this?
This PR updates the .NET version to 6, since .NET 5 is no longer updated, and .NET 6 is an LTS anyway.

This PR also does some updates to the project files to ensure examples aren't packed for NuGet, and it makes the project files more consistent, including bumping the language version to 9.

## 🔍 Why do we want this?
Consistency is good, and the `IsPackable` property will be needed to not publish the example projects with the reusable publish workflow.

## 🏗 How is it done?
Manual editing.

### 💥 Breaking changes
.NET 5 projects will start falling back to 3.1, but 5.0 is no longer a supported version.
