### PR TITLE
📝 Add NuGet metadata

### DIFF
--- a/Bearded.Graphics/Bearded.Graphics.csproj
+++ b/Bearded.Graphics/Bearded.Graphics.csproj
@@ -6,6 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <TargetFramework>net6.0</TargetFramework>
+    <AssemblyTitle>Bearded Graphics</AssemblyTitle>
+    <Description>Object oriented C# OpenGL graphics library build on top of OpenTK.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/beardgame/graphics</RepositoryUrl>
+    <PackageTags>game-development;gamedev;graphics;opengl;opentk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## ✨ What's this?
Add some metadata for the NuGet gallery (https://www.nuget.org/packages/Bearded.Utilities).
Specifically, a link back to the github repo, a MIT licence and a good description.

## 🔍 Why do we want this?
More clarity for people using the NuGet gallery.

## 🏗 How is it done?
Mostly moving metadata from the (no longer used) nuspec file to the project file, as is the best practice these days (https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices).

### 🔬 Why not another way?
It's best practice these days to use the project file instead of nuspec files (which you weren't using anymore anyways).

### 🦋 Side effects
Maybe the tags aren't up to date anymore?
