### PR TITLE
⬆️ Upgrade to OpenTK 4.8

### DIFF
--- a/Bearded.Graphics.ImageSharp/Bearded.Graphics.ImageSharp.csproj
+++ b/Bearded.Graphics.ImageSharp/Bearded.Graphics.ImageSharp.csproj
@@ -9,13 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTK.Core" Version="4.7.4" />
-        <PackageReference Include="OpenTK.Mathematics" Version="4.7.4" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="OpenTK.Graphics" Version="4.7.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Bearded.Graphics.SkiaSharp/Bearded.Graphics.SkiaSharp.csproj
+++ b/Bearded.Graphics.SkiaSharp/Bearded.Graphics.SkiaSharp.csproj
@@ -9,13 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTK.Core" Version="4.7.4" />
-        <PackageReference Include="OpenTK.Mathematics" Version="4.7.4" />
         <PackageReference Include="SkiaSharp" Version="2.88.6" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="OpenTK.Graphics" Version="4.7.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Bearded.Graphics.System.Drawing/Bearded.Graphics.System.Drawing.csproj
+++ b/Bearded.Graphics.System.Drawing/Bearded.Graphics.System.Drawing.csproj
@@ -8,13 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTK.Core" Version="4.7.4" />
-        <PackageReference Include="OpenTK.Mathematics" Version="4.7.4" />
         <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="OpenTK.Graphics" Version="4.7.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Bearded.Graphics/Bearded.Graphics.csproj
+++ b/Bearded.Graphics/Bearded.Graphics.csproj
@@ -10,10 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="Bearded.Utilities" Version="0.2.0.393-dev" />
-    <PackageReference Include="OpenTK.Graphics" Version="4.7.4" />
-    <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.4" />
-    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.4" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.4" />
+    <PackageReference Include="OpenTK.Core" Version="4.8.0" />
+    <PackageReference Include="OpenTK.Graphics" Version="4.8.0" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.8.0" />
+    <PackageReference Include="OpenTK.Windowing.Common" Version="4.8.0" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.8.0" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.8.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
## ✨ What's this?
This PR updates the OpenTK references to 4.8.

## 🔍 Why do we want this?
Since other Bearded libraries will continue to be up-to-date, the versions in this library also need to be updated to avoid runtime errors that are caused by the dynamic invocations of the windowing library.

## 🏗 How is it done?
I manually updated the references. I added Core and Mathematics as explicit references (which help solving ambiguous reference errors). I also removed the OpenTK dependencies from the image loading libraries, since they already get the references from the main library indirectly, and this prevents them from every going out of date.

### 💥 Breaking changes
Users will have to upgrade their own OpenTK references as well.

## 💡 Review hints
This was done inside the TD repository, which loads fine.