### PR TITLE
🐛 Fix FPS always being unlimited

### DIFF
--- a/Bearded.Graphics/Windowing/Window.cs
+++ b/Bearded.Graphics/Windowing/Window.cs
@@ -48,7 +48,7 @@ namespace Bearded.Graphics.Windowing
         [Obsolete("Legacy implementation. There is no replacement yet.")]
         protected NativeWindow NativeWindow => window;
 
-        private bool vsync = true;
+        private bool vsync = false;
 
         private bool forceResize = false;
 
@@ -108,14 +108,12 @@ namespace Bearded.Graphics.Windowing
         {
             window.AttachContextToCallingThread();
 
-            var targetUpdatesPerSecond = 60;
-            var targetDrawsPerSecond = 60;
+            var targetUpdatesPerSecond = 144;
+            var targetDrawsPerSecond = 144;
             var maximumFrameTimeFactor = 3;
 
-            var targetUpdateInterval = targetUpdatesPerSecond <= 0 ? 0 : 1 / targetUpdatesPerSecond;
-
-            targetUpdateInterval = targetUpdatesPerSecond <= 0 ? 0 : 1 / targetUpdatesPerSecond;
-            double targetRenderInterval = targetDrawsPerSecond <= 0 ? 0 : 1 / targetDrawsPerSecond;
+            var targetUpdateInterval = targetUpdatesPerSecond <= 0 ? 0 : 1.0 / targetUpdatesPerSecond;
+            var targetRenderInterval = targetDrawsPerSecond <= 0 ? 0 : 1.0 / targetDrawsPerSecond;
 
             var maximumUpdateInterval = targetUpdateInterval == 0
                 ? double.PositiveInfinity


### PR DESCRIPTION
## ✨ What's this?
This fixes the FPS to frame time division always being 0 when a frame rate of more than 1 is provided.

## 🔍 Why do we want this?
It causes infinite frame rates even when a frame rate cap is asked.

## 🏗 How is it done?
Replace the integer division by a double division.

