### PR TITLE
🏗️ Rework vertex data

### DIFF
--- a/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
+++ b/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.Basics</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Basics</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>

--- a/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
+++ b/Bearded.Graphics.Examples/01.Basics/Bearded.Graphics.Examples.01.Basics.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bearded.Graphics.Examples.Basics</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Basics</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>default</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
+++ b/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.IndexBuffer</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.IndexBuffer</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>

--- a/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
+++ b/Bearded.Graphics.Examples/02.IndexBuffer/Bearded.Graphics.Examples.02.IndexBuffer.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bearded.Graphics.Examples.IndexBuffer</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.IndexBuffer</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>default</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
+++ b/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.RenderSettings</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.RenderSettings</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>

--- a/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
+++ b/Bearded.Graphics.Examples/03.RenderSettings/Bearded.Graphics.Examples.03.RenderSettings.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bearded.Graphics.Examples.RenderSettings</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.RenderSettings</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>default</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
+++ b/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.PostProcessing</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.PostProcessing</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>

--- a/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
+++ b/Bearded.Graphics.Examples/08.PostProcessing/Bearded.Graphics.Examples.08.PostProcessing.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bearded.Graphics.Examples.PostProcessing</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.PostProcessing</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>default</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
+++ b/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.Text</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Text</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>

--- a/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
+++ b/Bearded.Graphics.Examples/12.Text/Bearded.Graphics.Examples.12.Text.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bearded.Graphics.Examples.Text</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Text</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>default</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/12.Text/UVVertexData.cs
+++ b/Bearded.Graphics.Examples/12.Text/UVVertexData.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Bearded.Graphics.Vertices;
 using OpenTK.Mathematics;
@@ -11,12 +12,11 @@ namespace Bearded.Graphics.Examples.Text
         private readonly Vector3 position;
         private readonly Vector2 uv;
 
-        public VertexAttribute[] VertexAttributes => vertexAttributes;
-
-        private static VertexAttribute[] vertexAttributes { get; } = MakeAttributeArray(
-            MakeAttributeTemplate<Vector3>("v_position"),
-            MakeAttributeTemplate<Vector2>("v_uv")
-        );
+        public static ImmutableArray<VertexAttribute> VertexAttributes { get; }
+            = MakeAttributeArray(
+                MakeAttributeTemplate<Vector3>("v_position"),
+                MakeAttributeTemplate<Vector2>("v_uv")
+            );
 
         public UVVertexData(Vector3 position, Vector2 uv)
         {

--- a/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
+++ b/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bearded.Graphics.Examples.Mandelbrot</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Mandelbrot</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>default</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>

--- a/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
+++ b/Bearded.Graphics.Examples/20.Mandelbrot/Bearded.Graphics.Examples.20.Mandelbrot.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bearded.Graphics.Examples.Mandelbrot</RootNamespace>
     <AssemblyName>Bearded.Graphics.Examples.Mandelbrot</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>

--- a/Bearded.Graphics.ImageSharp/Bearded.Graphics.ImageSharp.csproj
+++ b/Bearded.Graphics.ImageSharp/Bearded.Graphics.ImageSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Bearded.Graphics.ImageSharp</RootNamespace>

--- a/Bearded.Graphics.SkiaSharp/Bearded.Graphics.SkiaSharp.csproj
+++ b/Bearded.Graphics.SkiaSharp/Bearded.Graphics.SkiaSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Bearded.Graphics.SkiaSharp</RootNamespace>

--- a/Bearded.Graphics.System.Drawing/Bearded.Graphics.System.Drawing.csproj
+++ b/Bearded.Graphics.System.Drawing/Bearded.Graphics.System.Drawing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Bearded.Graphics.System.Drawing</RootNamespace>

--- a/Bearded.Graphics/Bearded.Graphics.csproj
+++ b/Bearded.Graphics/Bearded.Graphics.csproj
@@ -5,7 +5,7 @@
     <Nullable>annotations</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Bearded.Graphics/Core/Vertices/IVertexData.cs
+++ b/Bearded.Graphics/Core/Vertices/IVertexData.cs
@@ -1,15 +1,8 @@
-﻿
-namespace Bearded.Graphics.Vertices
+﻿using System.Collections.Immutable;
+
+namespace Bearded.Graphics.Vertices;
+
+public interface IVertexData
 {
-    /// <summary>
-    /// This interface must be implemented by any custom vertex data.
-    /// </summary>
-    public interface IVertexData
-    {
-        /// <summary>
-        /// Returns the vertex' <see cref="VertexAttributes"/>
-        /// </summary>
-        /// <returns>Array of <see cref="VertexAttribute"/></returns>
-        VertexAttribute[] VertexAttributes { get; }
-    }
+    static abstract ImmutableArray<VertexAttribute> VertexAttributes { get; }
 }

--- a/Bearded.Graphics/Core/Vertices/VertexAttribute.cs
+++ b/Bearded.Graphics/Core/Vertices/VertexAttribute.cs
@@ -1,38 +1,44 @@
-﻿using Bearded.Graphics.Shading;
+﻿using System;
+using Bearded.Graphics.Shading;
 using OpenTK.Graphics.OpenGL;
 
-namespace Bearded.Graphics.Vertices
+namespace Bearded.Graphics.Vertices;
+
+public readonly struct VertexAttribute(
+    string name,
+    int size,
+    VertexAttribPointerType type,
+    int stride,
+    int offset,
+    VertexAttributeFormat format)
 {
-    public sealed class VertexAttribute
+    public void SetAttribute(ShaderProgram program)
     {
-        private readonly string name;
-        private readonly int size;
-        private readonly VertexAttribPointerType type;
-        private readonly bool normalize;
-        private readonly int stride;
-        private readonly int offset;
+        var index = program.GetAttributeLocation(name);
+        if (index == StatusCode.NotFound)
+            return;
 
-        public VertexAttribute(
-            string name, int size, VertexAttribPointerType type, int stride, int offset, bool normalize = false)
+        GL.EnableVertexAttribArray(index);
+
+        switch (format)
         {
-            this.name = name;
-            this.size = size;
-            this.type = type;
-            this.stride = stride;
-            this.offset = offset;
-            this.normalize = normalize;
+            case VertexAttributeFormat.Float:
+                GL.VertexAttribPointer(index, size, type, false, stride, offset);
+                break;
+            case VertexAttributeFormat.FloatNormalized:
+                GL.VertexAttribPointer(index, size, type, true, stride, offset);
+                break;
+            case VertexAttributeFormat.Double:
+                GL.VertexAttribLPointer(index, size, VertexAttribDoubleType.Double, stride, new IntPtr(offset));
+                break;
+            case VertexAttributeFormat.Integer:
+                GL.VertexAttribIPointer(index, size, (VertexAttribIntegerType)type, stride, new IntPtr(offset));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
         }
-
-        public void SetAttribute(ShaderProgram program)
-        {
-            var index = program.GetAttributeLocation(name);
-            if (index == StatusCode.NotFound)
-                return;
-            GL.EnableVertexAttribArray(index);
-            GL.VertexAttribPointer(index, size, type, normalize, stride, offset);
-        }
-
-        public override string ToString() =>
-            $"{{name: {name}, size: {size}, type: {type}, normalize: {normalize}, stride: {stride}, offset: {offset}}}";
     }
+
+    public override string ToString() =>
+        $"{{name: {name}, size: {size}, type: {type}, format: {format}, stride: {stride}, offset: {offset}}}";
 }

--- a/Bearded.Graphics/Core/Vertices/VertexAttributeFormat.cs
+++ b/Bearded.Graphics/Core/Vertices/VertexAttributeFormat.cs
@@ -1,0 +1,9 @@
+﻿namespace Bearded.Graphics.Vertices;
+
+public enum VertexAttributeFormat
+{
+    Float,
+    FloatNormalized,
+    Double,
+    Integer,
+}

--- a/Bearded.Graphics/Core/Vertices/VertexAttributeTemplate.cs
+++ b/Bearded.Graphics/Core/Vertices/VertexAttributeTemplate.cs
@@ -1,45 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using OpenTK.Graphics.OpenGL;
 
-namespace Bearded.Graphics.Vertices
+namespace Bearded.Graphics.Vertices;
+
+public readonly struct VertexAttributeTemplate(
+    string name,
+    int size,
+    int bytes,
+    VertexAttribPointerType type,
+    VertexAttributeFormat format)
 {
-    public sealed class VertexAttributeTemplate
-    {
-        private static readonly ImmutableDictionary<VertexAttribPointerType, int> attributeByteSizes
-            = ImmutableDictionary.CreateRange(new Dictionary<VertexAttribPointerType, int>
-            {
-                { VertexAttribPointerType.Byte, 1 },
-                { VertexAttribPointerType.UnsignedByte, 1 },
-                { VertexAttribPointerType.Short, 2 },
-                { VertexAttribPointerType.UnsignedShort, 2 },
-                { VertexAttribPointerType.HalfFloat, 2 },
-                { VertexAttribPointerType.Int, 4 },
-                { VertexAttribPointerType.UnsignedInt, 4 },
-                { VertexAttribPointerType.Float, 4 },
-                { VertexAttribPointerType.Double, 8 },
-            });
-
-        private readonly string name;
-        private readonly int size;
-        private readonly VertexAttribPointerType type;
-        private readonly bool normalize;
-
-        public int Bytes { get; }
-
-        internal VertexAttributeTemplate(string name, int size, VertexAttribPointerType type, bool normalize)
-        {
-            if (!attributeByteSizes.TryGetValue(type, out var bytes))
-                throw new ArgumentException($"Unknown VertexAttribPointerType: {type}");
-
-            Bytes = bytes * size;
-            this.name = name;
-            this.size = size;
-            this.type = type;
-            this.normalize = normalize;
-        }
-
-        public VertexAttribute ToAttribute(int offset, int stride) => new(name, size, type, stride, offset, normalize);
-    }
+    public int Bytes => bytes;
+    public VertexAttribute ToAttribute(int offset, int stride) => new(name, size, type, stride, offset, format);
 }

--- a/Bearded.Graphics/Core/Vertices/VertexData.cs
+++ b/Bearded.Graphics/Core/Vertices/VertexData.cs
@@ -1,147 +1,106 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Bearded.Graphics.Shading;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
+using Half = OpenTK.Mathematics.Half;
 
-namespace Bearded.Graphics.Vertices
+namespace Bearded.Graphics.Vertices;
+
+using PointerType = VertexAttribPointerType;
+using Format = VertexAttributeFormat;
+using Defaults = (VertexAttribPointerType Type, int Count, int Bytes, VertexAttributeFormat DefaultFormat);
+
+public static class VertexData
 {
-    /// <summary>
-    /// This class contains helper types and methods to easily create vertex attribute layouts.
-    /// </summary>
-    public static class VertexData
+    public static void SetAttributes<TVertex>(ShaderProgram program)
+        where TVertex : struct, IVertexData
+        => SetAttributes(TVertex.VertexAttributes, program);
+
+    public static void SetAttributes<TCollection>(TCollection attributes, ShaderProgram program)
+        where TCollection : IEnumerable<VertexAttribute>
     {
-        public static void SetAttributes<TVertex>(ShaderProgram program)
-            where TVertex : struct, IVertexData
+        foreach (var attribute in attributes)
         {
-            SetAttributes(default(TVertex).VertexAttributes, program);
+            attribute.SetAttribute(program);
         }
-
-        public static void SetAttributes(VertexAttribute[] attributes, ShaderProgram program)
-        {
-            foreach (var attribute in attributes)
-            {
-                attribute.SetAttribute(program);
-            }
-        }
-
-        /// <summary>
-        /// Creates a <see cref="VertexAttribute"/> array from a list of attribute templates.
-        /// Offset and stride are calculated automatically, assuming zero padding.
-        /// </summary>
-        /// <param name="attributes">The attribute templates.</param>
-        public static VertexAttribute[] MakeAttributeArray(IList<VertexAttributeTemplate> attributes)
-        {
-            var stride = attributes.Sum(a => a.Bytes);
-            var array = new VertexAttribute[attributes.Count];
-            var offset = 0;
-            for (var i = 0; i < attributes.Count; i++)
-            {
-                var template = attributes[i];
-                array[i] = template.ToAttribute(offset, stride);
-                offset += template.Bytes;
-            }
-            return array;
-        }
-
-        /// <summary>
-        /// Creates a <see cref="VertexAttribute"/> array from a list of attribute templates.
-        /// Offset and stride are calculated automatically, assuming zero padding.
-        /// </summary>
-        /// <param name="attributes">The attribute templates.</param>
-        public static VertexAttribute[] MakeAttributeArray(params VertexAttributeTemplate[] attributes) =>
-            MakeAttributeArray((IList<VertexAttributeTemplate>) attributes);
-
-        /// <summary>
-        /// Creates a <see cref="VertexAttribute"/> array from a list of attribute templates.
-        /// Offset and stride are calculated automatically, assuming zero padding.
-        /// </summary>
-        /// <param name="attributes">The attribute templates.</param>
-        public static VertexAttribute[] MakeAttributeArray(IEnumerable<VertexAttributeTemplate> attributes) =>
-            MakeAttributeArray(attributes.ToList());
-
-        private static readonly ImmutableDictionary<Type, (VertexAttribPointerType Type, int Count, bool DefaultNormalize)> knownTypes
-            = ImmutableDictionary.CreateRange(new Dictionary<Type, (VertexAttribPointerType, int, bool)>
-            {
-                { typeof(float), (VertexAttribPointerType.Float, 1, false) },
-                { typeof(Vector2), (VertexAttribPointerType.Float, 2, false) },
-                { typeof(Vector3), (VertexAttribPointerType.Float, 3, false) },
-                { typeof(Vector4), (VertexAttribPointerType.Float, 4, false) },
-
-                { typeof(OpenTK.Mathematics.Half), (VertexAttribPointerType.HalfFloat, 1, false) },
-                { typeof(Vector2h), (VertexAttribPointerType.HalfFloat, 2, false) },
-                { typeof(Vector3h), (VertexAttribPointerType.HalfFloat, 3, false) },
-                { typeof(Vector4h), (VertexAttribPointerType.HalfFloat, 4, false) },
-
-                { typeof(double), (VertexAttribPointerType.Double, 1, false) },
-                { typeof(Vector2d), (VertexAttribPointerType.HalfFloat, 2, false) },
-                { typeof(Vector3d), (VertexAttribPointerType.HalfFloat, 3, false) },
-                { typeof(Vector4d), (VertexAttribPointerType.HalfFloat, 4, false) },
-
-                { typeof(byte), (VertexAttribPointerType.UnsignedByte, 1, true) },
-                { typeof(sbyte), (VertexAttribPointerType.Byte, 1, true) },
-
-                { typeof(short), (VertexAttribPointerType.Short, 1, false) },
-                { typeof(ushort), (VertexAttribPointerType.UnsignedShort, 1, false) },
-
-                { typeof(int), (VertexAttribPointerType.Int, 1, false) },
-                { typeof(uint), (VertexAttribPointerType.UnsignedInt, 1, false) },
-
-                { typeof(Color), (VertexAttribPointerType.UnsignedByte, 4, true) },
-            });
-
-        /// <summary>
-        /// Creates a vertex attribute template of a given basic type with and a given name.
-        /// </summary>
-        /// <param name="name">The name of the attribute in shader code.</param>
-        /// <param name="normalize">
-        /// Whether to normalize the attribute.
-        /// For null, only attributes of type <see cref="byte"/>, <see cref="sbyte"/>, and <see cref="Color"/> are normalised.
-        /// Default is null.
-        /// </param>
-        /// <typeparam name="T">
-        /// The type the attribute.
-        /// Supported are all signed and unsigned integer types, float, double and <see cref="Half"/>,
-        /// three and four dimensional vectors of all three floating point types, and <see cref="Color"/>.
-        /// </typeparam>
-        /// <exception cref="ArgumentException">The given type is not supported.</exception>
-        public static VertexAttributeTemplate MakeAttributeTemplate<T>(string name, bool? normalize = null) =>
-            MakeAttributeTemplate(name, typeof (T), normalize);
-
-        /// <summary>
-        /// Creates a vertex attribute template of a given basic type with and a given name.
-        /// </summary>
-        /// <param name="name">The name of the attribute in shader code.</param>
-        /// <param name="type">
-        /// The type the attribute.
-        /// Supported are all signed and unsigned integer types, float, double and <see cref="Half"/>,
-        /// three and four dimensional vectors of all three floating point types, and <see cref="Color"/>.
-        /// </param>
-        /// <param name="normalize">
-        /// Whether to normalize the attribute.
-        /// For null, only attributes of type <see cref="byte"/>, <see cref="sbyte"/>, and <see cref="Color"/> are normalised.
-        /// Default is null.
-        /// </param>
-        /// <exception cref="ArgumentException">The given type is not supported.</exception>
-        public static VertexAttributeTemplate MakeAttributeTemplate(string name, Type type, bool? normalize = null)
-        {
-            if(!knownTypes.TryGetValue(type, out var info))
-                throw new ArgumentException($"Unknown type: {type.Name}");
-
-            return MakeAttributeTemplate(name, info.Type, info.Count, normalize ?? info.DefaultNormalize);
-        }
-
-        /// <summary>
-        /// Creates a vertex attribute template of a given basic type with and a given name.
-        /// </summary>
-        /// <param name="name">The name of the attribute in shader code.</param>
-        /// <param name="type">The <see cref="VertexAttribPointerType"/> of the attribute.</param>
-        /// <param name="numberOfType">Number of components of the given type in this attribute.</param>
-        /// <param name="normalize">Whether to normalize the attribute.</param>
-        public static VertexAttributeTemplate MakeAttributeTemplate(
-                string name, VertexAttribPointerType type, int numberOfType, bool normalize = false) =>
-            new(name, numberOfType, type, normalize);
     }
+
+    public static ImmutableArray<VertexAttribute> MakeAttributeArray(IEnumerable<VertexAttributeTemplate> attributes)
+        => MakeAttributeArray(attributes.ToList());
+
+    public static ImmutableArray<VertexAttribute> MakeAttributeArray(params VertexAttributeTemplate[] attributes)
+        => MakeAttributeArray((ICollection<VertexAttributeTemplate>)attributes);
+
+    public static ImmutableArray<VertexAttribute> MakeAttributeArray(ICollection<VertexAttributeTemplate> attributes)
+    {
+        var stride = attributes.Sum(a => a.Bytes);
+        var array = ImmutableArray.CreateBuilder<VertexAttribute>(attributes.Count);
+        var offset = 0;
+        foreach (var template in attributes)
+        {
+            array.Add(template.ToAttribute(offset, stride));
+            offset += template.Bytes;
+        }
+
+        return array.MoveToImmutable();
+    }
+
+    public static VertexAttributeTemplate MakeAttributeTemplate<T>(string name, Format? format = null)
+        => MakeAttributeTemplate(name, typeof(T), format);
+
+    public static VertexAttributeTemplate MakeAttributeTemplate(string name, Type type, Format? format = null)
+    {
+        if (!knownTypes.TryGetValue(type, out var info))
+            throw new ArgumentException($"Unknown type: {type.Name}");
+
+        return MakeAttributeTemplate(name, info.Type, info.Count, info.Bytes, format ?? info.DefaultFormat);
+    }
+
+    public static VertexAttributeTemplate MakeAttributeTemplate(
+        string name, PointerType type, int numberOfType, int sizeInBytes, Format format)
+    {
+        if (format == Format.Integer && !isValidIntegerType(type))
+            throw new ArgumentException("Invalid type for integer vertex attribute. Must be an integer.");
+        if (format == Format.Double && type != PointerType.Double)
+            throw new ArgumentException("Invalid type for 64-bit vertex attribute. Must be Double.");
+
+        return new VertexAttributeTemplate(name, numberOfType, sizeInBytes, type, format);
+    }
+
+    private static bool isValidIntegerType(PointerType type)
+        => type is >= PointerType.Byte and <= PointerType.UnsignedInt;
+
+    private static readonly ReadOnlyDictionary<Type, Defaults> knownTypes
+        = new Dictionary<Type, Defaults>
+        {
+            { typeof(float), (PointerType.Float, 1, 4, Format.Float) },
+            { typeof(Vector2), (PointerType.Float, 2, 8, Format.Float) },
+            { typeof(Vector3), (PointerType.Float, 3, 12, Format.Float) },
+            { typeof(Vector4), (PointerType.Float, 4, 16, Format.Float) },
+
+            { typeof(Half), (PointerType.HalfFloat, 1, 2, Format.Float) },
+            { typeof(Vector2h), (PointerType.HalfFloat, 2, 4, Format.Float) },
+            { typeof(Vector3h), (PointerType.HalfFloat, 3, 6, Format.Float) },
+            { typeof(Vector4h), (PointerType.HalfFloat, 4, 8, Format.Float) },
+
+            { typeof(double), (PointerType.Double, 1, 8, Format.Double) },
+            { typeof(Vector2d), (PointerType.Double, 2, 16, Format.Double) },
+            { typeof(Vector3d), (PointerType.Double, 3, 24, Format.Double) },
+            { typeof(Vector4d), (PointerType.Double, 4, 32, Format.Double) },
+
+            { typeof(byte), (PointerType.UnsignedByte, 1, 1, Format.Integer) },
+            { typeof(sbyte), (PointerType.Byte, 1, 1, Format.Integer) },
+
+            { typeof(short), (PointerType.Short, 1, 2, Format.Integer) },
+            { typeof(ushort), (PointerType.UnsignedShort, 1, 2, Format.Integer) },
+
+            { typeof(int), (PointerType.Int, 1, 4, Format.Integer) },
+            { typeof(uint), (PointerType.UnsignedInt, 1, 4, Format.Integer) },
+
+            { typeof(Color), (PointerType.UnsignedByte, 4, 4, Format.FloatNormalized) },
+        }.AsReadOnly();
 }

--- a/Bearded.Graphics/PostProcessing/PostProcessingVertexData.cs
+++ b/Bearded.Graphics/PostProcessing/PostProcessingVertexData.cs
@@ -1,26 +1,25 @@
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Bearded.Graphics.Vertices;
 using OpenTK.Mathematics;
 using static Bearded.Graphics.Vertices.VertexData;
 
-namespace Bearded.Graphics.PostProcessing
+namespace Bearded.Graphics.PostProcessing;
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct PostProcessingVertexData : IVertexData
 {
-    [StructLayout(LayoutKind.Sequential)]
-    public readonly struct PostProcessingVertexData : IVertexData
-    {
-        private readonly Vector2 position;
+    private readonly Vector2 position;
 
-        public VertexAttribute[] VertexAttributes => vertexAttributes;
-
-        private static VertexAttribute[] vertexAttributes { get; } = MakeAttributeArray(
+    public static ImmutableArray<VertexAttribute> VertexAttributes { get; }
+        = MakeAttributeArray(
             MakeAttributeTemplate<Vector2>("v_position")
         );
 
-        public PostProcessingVertexData(Vector2 position)
-        {
-            this.position = position;
-        }
-
-        public override string ToString() => $"{position}";
+    public PostProcessingVertexData(Vector2 position)
+    {
+        this.position = position;
     }
+
+    public override string ToString() => $"{position}";
 }

--- a/Bearded.Graphics/Shapes/ColorVertexData.cs
+++ b/Bearded.Graphics/Shapes/ColorVertexData.cs
@@ -1,32 +1,33 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using Bearded.Graphics.Vertices;
 using OpenTK.Mathematics;
 using static Bearded.Graphics.Vertices.VertexData;
 
-namespace Bearded.Graphics.Shapes
+namespace Bearded.Graphics.Shapes;
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct ColorVertexData : IVertexData
 {
-    [StructLayout(LayoutKind.Sequential)]
-    public readonly struct ColorVertexData : IVertexData
+    private readonly Vector3 position;
+    private readonly Color color;
+
+    public ColorVertexData(float x, float y, float z, Color color)
+        : this(new Vector3(x, y, z), color)
     {
-        private readonly Vector3 position;
+    }
 
-        private readonly Color color;
+    public ColorVertexData(Vector3 position, Color color)
+    {
+        this.position = position;
+        this.color = color;
+    }
 
-        public VertexAttribute[] VertexAttributes => vertexAttributes;
-
-        private static VertexAttribute[] vertexAttributes { get; } = MakeAttributeArray(
+    public static ImmutableArray<VertexAttribute> VertexAttributes { get; }
+        = MakeAttributeArray(
             MakeAttributeTemplate<Vector3>("v_position"),
             MakeAttributeTemplate<Color>("v_color")
         );
 
-        public ColorVertexData(float x, float y, float z, Color color) : this(new Vector3(x, y, z), color) {}
-
-        public ColorVertexData(Vector3 position, Color color)
-        {
-            this.position = position;
-            this.color = color;
-        }
-
-        public override string ToString() => $"{position}, {color}";
-    }
+    public override string ToString() => $"{position}, {color}";
 }


### PR DESCRIPTION
## ✨ What's this?
I started with wanting to support integer vertex attributes.

Doubles looked supported but were broken because of the wrong GL method call and because of a copy-paste error.

Refamiliarising myself with the relevant GL methods, I also realised that integer normalisation works differently than I thought, and decided that it should default to not normalise anything - except Color, which is specifically intended to be normalised.

I also believed there was confusion about how byte sizes were calculated - though then realised it was working correctly after all and undid the changes, replacing the previous dictionary with a switch expression due to likely compiler optimisations.

### Caveat
This latter point highlights a bigger issue, which is that the vertex attribute stride is currently calculated as the sum of vertex attribute sizes, which is not necessarily correct and depends on the struct layout and packing settings. Instead, it would be more correct to inspect the structs with reflection and other methods to get the actual byte offsets of fields annotated with attributes for names and format settings and alignment in arrays. I would also like to have an attribute that forces a check, perhaps at compile time or with an analyser, or if needed at runtime, to see if vertices are optimally laid out and aligned, so that they waste no space, no performance due to bad alignment inside arrays, and can be copied to GPU memory AS IS, instead of requiring expensive transformation of the data.

However, none of that is inside the scope of this PR.

## 🔍 Why do we want this?
- Fixes bugs and unclear behaviour around normalisation
- Enable integer and double attributes

### 💥 Breaking changes
IVertexData and VertexData public interfaces have changed, requiring all vertices to be updated, though most of them only require making the interface method static, and changing its return type - source compatibility is otherwise largely maintained, as long as the previous optional normalisation parameter was not specified.

The default for all integer attributes is now not to be normalised, whereas before signed and unsigned bytes were.

### 🔬 Why not another way?
Could have done it without breaking changes, but it would have made interfaces less clear and perhaps even ambiguous.

While the above caveat remains the same, at least this new version is less and clearer code, easier to use, etc. and should not require any more changes until we perhaps redo it all again as indicated in the caveat.
