### PR TITLE
⬆️ Upgrade to ImageSharp 3

### DIFF
--- a/Bearded.Graphics.ImageSharp/Bearded.Graphics.ImageSharp.csproj
+++ b/Bearded.Graphics.ImageSharp/Bearded.Graphics.ImageSharp.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Bearded.Graphics.ImageSharp/ImageTextureData.cs
+++ b/Bearded.Graphics.ImageSharp/ImageTextureData.cs
@@ -1,18 +1,23 @@
 ﻿using Bearded.Graphics.Textures;
 using OpenTK.Graphics.OpenGL;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace Bearded.Graphics.ImageSharp;
 
 public sealed class ImageTextureData : ITextureData
 {
-    private static readonly Configuration configuration;
+    private static readonly DecoderOptions decoderOptions;
 
     static ImageTextureData()
     {
-        configuration = Configuration.Default.Clone();
+        var configuration = Configuration.Default.Clone();
         configuration.PreferContiguousImageBuffers = true;
+        decoderOptions = new DecoderOptions
+        {
+            Configuration = configuration
+        };
     }
 
     private readonly Image<Bgra32> image;
@@ -21,21 +26,22 @@ public sealed class ImageTextureData : ITextureData
 
     public int Height { get; }
 
-    public static ITextureData From(string path) => new ImageTextureData(Image.Load<Bgra32>(configuration, path));
+    public static ITextureData From(string path) => new ImageTextureData(Image.Load<Bgra32>(decoderOptions, path));
 
-    public static ITextureData From(Stream stream) => new ImageTextureData(Image.Load<Bgra32>(configuration, stream));
+    public static ITextureData From(Stream stream) => new ImageTextureData(Image.Load<Bgra32>(decoderOptions, stream));
 
-    public static ITextureData From(Image bitmap) => new ImageTextureData(bitmap.CloneAs<Bgra32>(configuration));
+    public static ITextureData From(Image bitmap) => new ImageTextureData(bitmap.CloneAs<Bgra32>(
+        decoderOptions.Configuration));
 
     public static ITextureData From(string path, IEnumerable<ITextureTransformation> transformations)
     {
-        using var image = Image.Load<Bgra32>(configuration, path);
+        using var image = Image.Load<Bgra32>(decoderOptions, path);
         return From(image, transformations);
     }
 
     public static ITextureData From(Stream stream, IEnumerable<ITextureTransformation> transformations)
     {
-        using var image = Image.Load<Bgra32>(configuration, stream);
+        using var image = Image.Load<Bgra32>(decoderOptions, stream);
         return From(image, transformations);
     }
 


### PR DESCRIPTION
## ✨ What's this?
Upgrades ImageSharp to 3.1.3. This includes updating some method calls to their new signatures.

### 🔗 Relationships
See #74 

## 🔍 Why do we want this?
There is a security vulnerability in ImageSharp 2 and it keeps trying to tell me everywhere 😛 

## 🏗 How is it done?
Updated the package, then resolved all build errors.

### 💥 Breaking changes
Might break compatibility with other people who use ImageSharp 2 still. TD uses 3 though.

### 🔬 Why not another way?
Need to bump it somehow.

## 💡 Review hints
I've run a clean build of TD with this Bearded.Graphics version and it builds and runs fine. Things are drawn as expected.
