### PR TITLE
🛠️ Allow custom blend modes in pipeline

### DIFF
--- a/Bearded.Graphics/Pipelines/Context/BlendMode.cs
+++ b/Bearded.Graphics/Pipelines/Context/BlendMode.cs
@@ -1,14 +1,19 @@
-namespace Bearded.Graphics.Pipelines.Context
+using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.BlendingFactor;
+using static OpenTK.Graphics.OpenGL.BlendEquationMode;
+
+namespace Bearded.Graphics.Pipelines.Context;
+
+public readonly record struct BlendMode(
+    BlendingFactor Source, BlendingFactor Destination, BlendEquationMode Function)
 {
-    public enum BlendMode
-    {
-        None = 0,
-        Alpha,
-        Add,
-        Subtract,
-        Multiply,
-        Premultiplied,
-        Min,
-        Max,
-    }
+    public static BlendMode Disable => default;
+
+    public static BlendMode Alpha => new(SrcAlpha, OneMinusSrcAlpha, FuncAdd);
+    public static BlendMode Add => new(SrcAlpha, One, FuncAdd);
+    public static BlendMode Subtract => new(SrcAlpha, One, FuncReverseSubtract);
+    public static BlendMode Multiply => new(Zero, SrcColor, FuncAdd);
+    public static BlendMode Premultiplied => new(One, OneMinusSrcAlpha, FuncAdd);
+    public static BlendMode Min => new(One, One, BlendEquationMode.Min);
+    public static BlendMode Max => new(One, One, BlendEquationMode.Max);
 }

--- a/Bearded.Graphics/Pipelines/Context/GLState.cs
+++ b/Bearded.Graphics/Pipelines/Context/GLState.cs
@@ -2,8 +2,6 @@ using System;
 using System.Drawing;
 using OpenTK.Graphics.OpenGL;
 using static Bearded.Graphics.Pipelines.Context.CullMode;
-using static OpenTK.Graphics.OpenGL.BlendEquationMode;
-using static OpenTK.Graphics.OpenGL.BlendingFactor;
 
 namespace Bearded.Graphics.Pipelines.Context
 {
@@ -53,7 +51,7 @@ namespace Bearded.Graphics.Pipelines.Context
         {
             BlendMode = mode;
 
-            if (mode == BlendMode.None)
+            if (mode == BlendMode.Disable)
             {
                 GL.Disable(EnableCap.Blend);
                 return;
@@ -61,19 +59,7 @@ namespace Bearded.Graphics.Pipelines.Context
 
             GL.Enable(EnableCap.Blend);
 
-            // TODO: refactor to work similarly to depth mode to make more flexible
-            var (src, dst, equation) = mode switch
-            {
-                BlendMode.Alpha => (SrcAlpha, OneMinusSrcAlpha, FuncAdd),
-                BlendMode.Add => (SrcAlpha, One, FuncAdd),
-                BlendMode.Subtract => (SrcAlpha, One, FuncReverseSubtract),
-                BlendMode.Multiply => (Zero, SrcColor, FuncAdd),
-                BlendMode.Premultiplied => (One, OneMinusSrcAlpha, FuncAdd),
-                BlendMode.Min => (One, One, Min),
-                BlendMode.Max => (One, One, Max),
-                BlendMode.None => throw new InvalidOperationException(),
-                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
-            };
+            var (src, dst, equation) = mode;
 
             GL.BlendFunc(src, dst);
             GL.BlendEquation(equation);


### PR DESCRIPTION
## ✨ What's this?
What it says on the tin.

## 🔍 Why do we want this?
There's a lot of different blend mode combinations given the three parameters and their possible values. I want to experiment with them more freely. This allows me to do that, exposing all blend modes OpenGL supports.

## 🏗 How is it done?
Use a struct containing the actual blend more parameters instead of an enum and expose a public constructor.

### 💥 Breaking changes
Type changed from enum to struct, but maintains any reasonable-use source compatibility.
