### PR TITLE
🐛 Fix builds by using correct .NET version

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-dotnet@v3.0.0
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-dotnet@v3.0.0
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
## ✨ What's this?
This PR fixes the GitHub Actions so they actually pass.

## 🔍 Why do we want this?
To validate incoming PRs.

Previously the .NET version of all projects was incremented, but GH actions wasn't updated. Why the builds were green up to now is a mystery to me.